### PR TITLE
Pipeline depends_on bug

### DIFF
--- a/routes/pipeline.js
+++ b/routes/pipeline.js
@@ -56,7 +56,7 @@ router.post('/add_pipeline', common.ensureAuthenticated, function(req, res) {
   var depends_on = {};
   doc.pipeline.forEach(n => {
     if (typeof n.upstream == 'undefined' || n.upstream.length == 0) depends_on[n.input_var] = 1;
-    if (n.type == 'InfluxSinkNode') depends_on[n.output_var] = 1;});
+  });
   doc['depends_on'] = Object.keys(depends_on);
   if (typeof doc.node_config == 'undefined')
     doc['node_config'] = {};


### PR DESCRIPTION
This one somehow slipped through. Basically what happens if the output is in the depends_on list, is that every time a value is converted  and written to the database there is immediately a new value that triggers a new cycle. Only SourceNodes must be in the depends_on list.