### PR TITLE
Pipeline updates

### DIFF
--- a/public/javascripts/default_scripts.js
+++ b/public/javascripts/default_scripts.js
@@ -120,7 +120,7 @@ function SensorDropdown(sensor) {
 function MakeAlarm(name) {
   if (typeof name == 'undefined')
     name = $("#detail_sensor_name").html();
-  let desc = $("#sensor_desc").html();
+  let desc = $("#sensor_desc").val();
   var template = {
     name: `alarm_${name}`,
     description: desc,

--- a/public/javascripts/default_scripts.js
+++ b/public/javascripts/default_scripts.js
@@ -118,10 +118,13 @@ function SensorDropdown(sensor) {
 }
 
 function MakeAlarm(name) {
+  let desc = '';
   if (typeof name == 'undefined')
     name = $("#detail_sensor_name").html();
+    desc = $("#detail_sensor_description").html();
   var template = {
     name: `alarm_${name}`,
+    description: desc,
     node_config: {},
     status: 'inactive',
     pipeline: [

--- a/public/javascripts/default_scripts.js
+++ b/public/javascripts/default_scripts.js
@@ -118,10 +118,9 @@ function SensorDropdown(sensor) {
 }
 
 function MakeAlarm(name) {
-  let desc = '';
   if (typeof name == 'undefined')
     name = $("#detail_sensor_name").html();
-    desc = $("#detail_sensor_description").html();
+  let desc = $("#detail_sensor_description").html();
   var template = {
     name: `alarm_${name}`,
     description: desc,

--- a/public/javascripts/default_scripts.js
+++ b/public/javascripts/default_scripts.js
@@ -120,7 +120,7 @@ function SensorDropdown(sensor) {
 function MakeAlarm(name) {
   if (typeof name == 'undefined')
     name = $("#detail_sensor_name").html();
-  let desc = $("#detail_sensor_description").html();
+  let desc = $("#sensor_desc").html();
   var template = {
     name: `alarm_${name}`,
     description: desc,

--- a/public/javascripts/pipeline.js
+++ b/public/javascripts/pipeline.js
@@ -35,7 +35,10 @@ function PopulatePipelines(flavor) {
       let status_color = ((last_error < 5) ? 'danger' : 'success');
       if(doc.cycle === 0) status_color = 'secondary' // status indicator grey when pipeline never ran
       $(`#${flavor}_${status}`).append(`<tr><td onclick="PipelineDropdown('${n}')">` +
-          `<span class="badge p-2 bg-${status_color} rounded-circle"><span class="visually-hidden">X</span></span></td>` +
+          `<span class="badge p-2 bg-${status_color} rounded-circle" data-bs-toggle="tooltip" data-bs-placement="right"` +
+          `title="process time: &nbsp; ${doc.rate.toPrecision(3)} ms  \n`+
+          `last cycle: &nbsp; ${(doc.dt || 0).toPrecision(1)} s \n`+
+          `last error: &nbsp; ${doc.cycle-doc.error} cycles ago"><span class="visually-hidden">X</span></span></td>` +
           `<td onclick="PipelineDropdown('${n}')">${n}</td>` +
           `<td id="${n}_description" onclick="PipelineDropdown('${n}')">${doc.description}</td>` +
           `<td id="${n}_actions">Loading</td></tr>`);
@@ -51,6 +54,7 @@ function PopulatePipelines(flavor) {
       } else {
         $(`#${n}_actions`).html(`${start_button}`);
       }
+      $('[data-bs-toggle="tooltip"]').tooltip();
     }); // data.forEach
   }); // getJSON
 }
@@ -94,6 +98,7 @@ function SilenceDropdown(name) {
 function AlarmTemplate() {
   return {
     name: 'alarm_NAME',
+    description: '',
     pipeline: [
       {
         name: 'source_NAME',
@@ -114,6 +119,7 @@ function AlarmTemplate() {
 function ControlTemplate() {
   return {
     name: 'control_NAME',
+    description: '',
     pipeline: [
       {
         name: 'source_A',
@@ -167,6 +173,7 @@ function ControlTemplate() {
 function ConvertTemplate() {
   return {
     name: 'convert_NAME',
+    description: '',
     pipeline: [
       {
         name: 'source_NAME',

--- a/public/javascripts/pipeline.js
+++ b/public/javascripts/pipeline.js
@@ -21,9 +21,6 @@ function UpdateLoop() {
 
 function PopulatePipelines(flavor) {
   var filter = $("#searchPipelineInput").val().toUpperCase();
-  var silent = 'fas fa-bell-slash';
-  var active = 'fas fa-bell';
-  var restart = "fas fa-angle-double-left";
   $.getJSON(`/pipeline/get_pipelines?flavor=${flavor}`, data => {
     $(`#${flavor}_active`).empty();
     $(`#${flavor}_silent`).empty();
@@ -263,23 +260,41 @@ function FillTemplate(which) {
 function AddOrUpdatePipeline() {
   if (ValidatePipeline(false)) {
     var doc = JSON.parse(JSON.stringify(document.jsoneditor.get()));
-    if (typeof doc._id != 'undefined')
-      delete doc._id;
-    $.ajax({
-      type: 'POST',
-      url: "/pipeline/add_pipeline",
-      data: doc,
-      success: (data) => {
-        if (typeof data != 'undefined' && typeof data.err != 'undefined')
-          alert(data.err);
-        else {
-          $("#pipelinebox").modal('hide');
-          Notify(data.notify_msg, data.notify_status);
-        }
-      },
-      error: (jqXHR, textStatus, errorCode) => alert(`Error: ${textStatus}, ${errorCode}`),
-    });
+    let old_name = $('#detail_pipeline_name').html();
+    if (old_name.startsWith("New")) {
+      $.ajax({
+        type: 'POST',
+        url: "/pipeline/add_pipeline",
+        data: doc,
+        success: (data) => {
+          if (typeof data != 'undefined' && typeof data.err != 'undefined')
+            alert(data.err);
+          else {
+            $("#pipelinebox").modal('hide');
+            Notify(data.notify_msg, data.notify_status);
+          }
+        },
+        error: (jqXHR, textStatus, errorCode) => alert(`Error: ${textStatus}, ${errorCode}`),
+      });
+    } else {
+      doc.old_name = old_name;
+      $.ajax({
+        type: 'POST',
+        url: "/pipeline/update_pipeline",
+        data: doc,
+        success: (data) => {
+          if (typeof data != 'undefined' && typeof data.err != 'undefined')
+            alert(data.err);
+          else {
+            $("#pipelinebox").modal('hide');
+            Notify(data.notify_msg, data.notify_status);
+          }
+        },
+        error: (jqXHR, textStatus, errorCode) => alert(`Error: ${textStatus}, ${errorCode}`),
+      });
+    }
   }
+
 }
 
 

--- a/public/javascripts/pipeline.js
+++ b/public/javascripts/pipeline.js
@@ -37,22 +37,8 @@ function PopulatePipelines(flavor) {
       $(`#${flavor}_${status}`).append(`<tr><td onclick="PipelineDropdown('${n}')">` +
           `<span class="badge p-2 bg-${status_color} rounded-circle"><span class="visually-hidden">X</span></span></td>` +
           `<td onclick="PipelineDropdown('${n}')">${n}</td>` +
-          `<td id="${n}_description" onclick="PipelineDropdown('${n}')">Loading</td>` +
+          `<td id="${n}_description" onclick="PipelineDropdown('${n}')">${doc.description}</td>` +
           `<td id="${n}_actions">Loading</td></tr>`);
-      if (flavor == 'alarm') {
-        let alarm_name = n.split(/_(.*)/s)[1]; // get name of alarm without 'alarm_'
-        $.getJSON(`/devices/sensor_list`, sensor_list => {
-          if (sensor_list.includes(alarm_name)) {
-            $.getJSON(`sensor_detail?sensor=${alarm_name}`, sensor_detail => {
-              $(`#${n}_description`).html(`${sensor_detail.description}`);
-            });
-          } else {
-            $(`#${n}_description`).html(`${doc.description}`);
-          }
-        });
-      } else {
-        $(`#${n}_description`).html(`${doc.description}`);
-      }
       let stop_button = `<button class="btn btn-danger action_button" onclick="PipelineControl('stop','${n}')"><i class="fas fa-solid fa-stop"></i>Stop</button>`;
       let silence_button = `<button class="btn btn-secondary action_button" onclick="SilenceDropdown('${n}')"><i class="fas fa-solid fa-bell-slash"></i>Silence</button>`;
       let activate_button = `<button class="btn btn-success action_button" onclick="PipelineControl('active','${n}')"><i class="fas fa-solid fa-bell"></i>Activate</button>`;

--- a/public/stylesheets/default_style.css
+++ b/public/stylesheets/default_style.css
@@ -99,3 +99,11 @@ ul.CTAs li a {
   white-space: nowrap;
   padding-right: 20px;
 }
+
+.action_button i {
+  margin-right: 5px;
+}
+
+#pipelines_of_sensor_table tbody tr td {
+  vertical-align: middle;
+}

--- a/public/stylesheets/default_style.css
+++ b/public/stylesheets/default_style.css
@@ -107,3 +107,7 @@ ul.CTAs li a {
 #pipelines_of_sensor_table tbody tr td {
   vertical-align: middle;
 }
+
+.tooltip-inner {
+  white-space: pre-wrap;
+}

--- a/public/stylesheets/pipeline.css
+++ b/public/stylesheets/pipeline.css
@@ -7,3 +7,7 @@
 .action_button {
   margin-right : 10px;
 }
+
+.tooltip-inner {
+  white-space: pre-wrap;
+}

--- a/public/stylesheets/pipeline.css
+++ b/public/stylesheets/pipeline.css
@@ -1,10 +1,9 @@
 .table tbody tr td {
   word-wrap: break-word;
-  max-width: 150px;
+  max-width: 300px;
+  vertical-align: middle;
 }
-.table tbody tr td i {
-  margin-right: 5px;
-}
-.table tbody tr td i:hover {
-  color: #6c757d;
+
+.action_button {
+  margin-right : 10px;
 }

--- a/public/stylesheets/pipeline.css
+++ b/public/stylesheets/pipeline.css
@@ -8,6 +8,3 @@
   margin-right : 10px;
 }
 
-.tooltip-inner {
-  white-space: pre-wrap;
-}

--- a/routes/pipeline.js
+++ b/routes/pipeline.js
@@ -50,6 +50,35 @@ router.post('/add_pipeline', common.ensureAuthenticated, function(req, res) {
       doc.pipeline.length == 0)
     return res.json({err: 'Bad input'});
   doc['name'] = doc.name;
+  doc['status'] = 'inactive';
+  doc['description'] = String(doc.description);
+  doc['cycles'] = parseInt('0');
+  doc['error'] = parseInt('0');
+  doc['rate'] = -1;
+  var depends_on = {};
+  doc.pipeline.forEach(n => {
+    if (typeof n.upstream == 'undefined' || n.upstream.length == 0) depends_on[n.input_var] = 1;
+  });
+  doc['depends_on'] = Object.keys(depends_on);
+  if (typeof doc.node_config == 'undefined')
+    doc['node_config'] = {};
+  req.db.get('pipelines').insert(doc)
+      .then(() => req.db.get('sensors').update({name: {$in: doc['depends_on']}},
+          {$addToSet: {'pipelines': doc['name']}}, {multi: true}))
+      .then(res.json({notify_msg: 'Pipeline added', notify_status: 'success'}))
+      .catch(err => {console.log(err.message); return res.json({err: err.message});});
+});
+
+router.post('/update_pipeline', common.ensureAuthenticated, function(req, res) {
+  var doc = req.body;
+  let old_name = doc.old_name;
+  delete doc.old_name;
+  if (typeof doc.name == 'undefined' ||
+      !['alarm', 'control', 'convert'].includes(doc.name.split('_')[0]) ||
+      typeof doc.pipeline == 'undefined' ||
+      doc.pipeline.length == 0)
+    return res.json({err: 'Bad input'});
+  doc['name'] = doc.name;
   doc['status'] = doc.status || 'inactive';
   doc['description'] = String(doc.description);
   doc['cycles'] = parseInt('0');
@@ -62,15 +91,13 @@ router.post('/add_pipeline', common.ensureAuthenticated, function(req, res) {
   doc['depends_on'] = Object.keys(depends_on);
   if (typeof doc.node_config == 'undefined')
     doc['node_config'] = {};
-  req.db.get('pipelines').count({name: doc.name}).then(function(count) {
-    return (count ? 'Pipeline changed' : 'Pipeline added')
-  })
-      .then((message) => res.json({notify_msg: message, notify_status: 'success'}))
-      .then(req.db.get('pipelines').update({name: doc.name}, doc, {upsert: true, replaceOne: true}))
-      .then(() => req.db.get('sensors').update({}, {$pull: {'pipelines': doc.name}}, {multi: true}))
+  req.db.get('pipelines').update({_id: doc._id}, doc, {replaceOne: true})
+      .then(() => req.db.get('sensors').update({}, {$pull: {'pipelines': old_name}}, {multi: true}))
       .then(() => req.db.get('sensors').update({name: {$in: doc['depends_on']}},
-      {$addToSet: {'pipelines': doc['name']}}, {multi: true}))
+          {$addToSet: {'pipelines': doc['name']}}, {multi: true}))
+      .then(res.json({notify_msg: 'Pipeline updated', notify_status: 'success'}))
       .catch(err => {console.log(err.message); return res.json({err: err.message});});
+
 });
 
 router.post('/delete_pipeline', common.ensureAuthenticated, function(req, res) {

--- a/routes/pipeline.js
+++ b/routes/pipeline.js
@@ -50,6 +50,7 @@ router.post('/add_pipeline', common.ensureAuthenticated, function(req, res) {
       doc.pipeline.length == 0)
     return res.json({err: 'Bad input'});
   doc['status'] = doc.status || 'inactive';
+  doc['description'] = String(doc.description);
   doc['cycles'] = parseInt('0');
   doc['error'] = parseInt('0');
   doc['rate'] = -1;

--- a/routes/pipeline.js
+++ b/routes/pipeline.js
@@ -49,6 +49,7 @@ router.post('/add_pipeline', common.ensureAuthenticated, function(req, res) {
       typeof doc.pipeline == 'undefined' || 
       doc.pipeline.length == 0)
     return res.json({err: 'Bad input'});
+  doc['name'] = doc.name;
   doc['status'] = doc.status || 'inactive';
   doc['description'] = String(doc.description);
   doc['cycles'] = parseInt('0');

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -363,6 +363,7 @@ html
 
     script.
       $(document).ready(()=>{
+        $('[data-bs-toggle="tooltip"]').tooltip({trigger: 'hover'});
         if ($("#login_dropdown").html() == 'Login') {
           $("#login_button").show();
           $("#logout_button").hide();

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -182,7 +182,20 @@ html
                 hr
               h5 Pipelines involving this sensor
               br
-              ul#pipeline_list
+              table.table(style="width:100%;")
+                thead
+                  tr
+                    th(colspan='2') Active
+                tbody#pipelines_active
+                thead
+                  tr
+                    th(colspan='2') Silenced
+                tbody#pipelines_silenced
+                thead
+                  tr
+                    th(colspan='2') Inactive
+                tbody#pipelines_inactive
+              button.btn.btn-primary#make_alarm_button(onclick=`MakeAlarm()`) Make new alarm
               hr
               h5 Recent history
               br

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -182,7 +182,7 @@ html
                 hr
               h5 Pipelines involving this sensor
               br
-              table.table(style="width:100%;")
+              table.table#pipelines_of_sensor_table(style="width:100%;")
                 thead
                   tr
                     th(colspan='2') Active

--- a/views/pipeline.pug
+++ b/views/pipeline.pug
@@ -12,6 +12,7 @@ block extrahead
 
 block content
   - var flavors = ['alarm', 'control', 'convert'];
+  - var states = ['active', 'silent', 'inactive'];
   div.main-container
     #pipelineAccordion.accordion
       each flavor in flavors
@@ -21,55 +22,19 @@ block content
               | #{flavor.toUpperCase()} PIPELINES
           .accordion-collapse.collapse.show(id=`${flavor}_tables`, aria-labelledby=`${flavor}_header` data-bs-parent='#pipelineAccordion')
             .accordion-body
-              h3 Active pipelines &nbsp
-                i.fas.fa-bell
-              table.table.table-striped.table-hover
-                thead
-                  tr
-                    th Name
-                    th Process time [ms] &nbsp
-                      i.fas.fa-solid.fa-circle-question(data-bs-toggle="tooltip" data-bs-html="true"
-                        title="It takes of order 10ms to get a value from Influx.<br><br>" +
-                        "If the process time is faster than this, something's not working, " +
-                        "and there'll probably be new entries in the logs.<br><br>" +
-                        "Pipelines only run as fast as the slowest sensor they depend on. " +
-                        "If you want a faster pipeline, speed up the sensors.")
-
-                    th Seconds since last cycle
-                    th Cycles since last error &nbsp
-                      i.fas.fa-solid.fa-circle-question(data-bs-toggle="tooltip" data-bs-html="true"
-                        title="The internal buffers take a few cycles to fill, so there can be \"errors\" shortly " +
-                        "after pipeline startup.<br><br>As long as the error number is small and the cycle number isn't, it's fine")
-                    th Actions
-                tbody.pipeline_table(id=`${flavor}_active`)
-                  tr
-                    td(colspan=7) Loading!
-              br
-              h3 Silent pipelines &nbsp;
-                i.fas.fa-bell-slash
-              table.table.table-hover.table-striped
-                thead
-                  tr
-                    th Name
-
-                    th Process time [ms]
-                    th Seconds since last cycle
-                    th Cycles since last error
-                    th Actions
-                tbody.pipeline_table(id=`${flavor}_silent`)
-                  tr
-                    td(colspan=7) Loading!
-              br
-              h3 Inactive pipelines &nbsp;
-                i.fas.fa-hand-paper
-              table.table.table-hover.table-striped
-                thead
-                  tr
-                    th Name
-                    th Start
-                tbody.pipeline_table(id=`${flavor}_inactive`)
-                  tr
-                    td(colspan=2) Loading!
+              each status in states
+                  h3 #{status} pipelines &nbsp;
+                    i.fas.fa-bell
+                  table.table.table-striped.table-hover
+                    thead
+                      tr
+                        th Name
+                        th Description
+                        th Actions
+                    tbody.pipeline_table(id=`${flavor}_${status}`)
+                      tr
+                        td(colspan=2) Loading!
+                  br
 
 
     #silence_dropdown.modal.fade
@@ -118,7 +83,7 @@ block content
       document.jsoneditor = new JSONEditor(document.getElementById('json_text'),
               {"modes": ['tree', 'view', 'form', 'code', 'text']});
       ['alarm', 'control', 'convert'].forEach(pl => PopulatePipelines(pl));
-      setInterval(UpdateLoop, 5000);
+      //setInterval(UpdateLoop, 5000);
       $('[data-bs-toggle="tooltip"]').tooltip({trigger: 'hover'});
       var query_search = new URLSearchParams(window.location.search);
       if (query_search.has('pipeline_id')) {

--- a/views/pipeline.pug
+++ b/views/pipeline.pug
@@ -83,7 +83,7 @@ block content
       document.jsoneditor = new JSONEditor(document.getElementById('json_text'),
               {"modes": ['tree', 'view', 'form', 'code', 'text']});
       ['alarm', 'control', 'convert'].forEach(pl => PopulatePipelines(pl));
-      //setInterval(UpdateLoop, 5000);
+      setInterval(UpdateLoop, 5000);
       $('[data-bs-toggle="tooltip"]').tooltip({trigger: 'hover'});
       var query_search = new URLSearchParams(window.location.search);
       if (query_search.has('pipeline_id')) {

--- a/views/pipeline.pug
+++ b/views/pipeline.pug
@@ -80,8 +80,22 @@ block content
   script.
     $(document).ready(function() {
       PopulateNavbar();
-      document.jsoneditor = new JSONEditor(document.getElementById('json_text'),
-              {"modes": ['tree', 'view', 'form', 'code', 'text']});
+      const options = {
+        "mode": "tree",
+        onEditable: function (node) {
+          switch (node.field) {
+            case 'name':
+            case 'description':
+            case 'pipeline':
+            case 'node_config':
+              return {field: false, value: true}
+            default:
+              return {field: false, value: false}
+          }
+        }
+      }
+
+      document.jsoneditor = new JSONEditor(document.getElementById('json_text'), options);
       ['alarm', 'control', 'convert'].forEach(pl => PopulatePipelines(pl));
       setInterval(UpdateLoop, 5000);
       $('[data-bs-toggle="tooltip"]').tooltip({trigger: 'hover'});

--- a/views/pipeline.pug
+++ b/views/pipeline.pug
@@ -24,16 +24,16 @@ block content
             .accordion-body
               each status in states
                   h3 #{status} pipelines &nbsp;
-                    i.fas.fa-bell
                   table.table.table-striped.table-hover
                     thead
                       tr
+                        th Status
                         th Name
                         th Description
                         th Actions
                     tbody.pipeline_table(id=`${flavor}_${status}`)
                       tr
-                        td(colspan=2) Loading!
+                        td(colspan=4) Loading!
                   br
 
 


### PR DESCRIPTION
This PR adresses issues #26 #19 and #16 - as far as I agree with it.
In detail:

- We move the pipeline metrics into a status light which is green when the last error is more than 5 cycles ago and red otherwise. Hover to get the complete information as a tooltip.
- I suggest keeping the naming scheme as is (with underscores) and also display it as is. Everything else leads to more confusion than it helps IMO. 
- Each pipeline shows its description in the overview page, which is stored in the pipeline's DB document. If you press the 'Make new alarm' button it will take the sensor's description by default, but in principle they are independent of each other. (This makes the query easier and was my fix to the flickering) 
- Pipeline action buttons are now larger for better use on mobile devices.
- In the sensor detail modal, we added the possibility to start and stop pipelines directly (no silence button here - should it?).
- You can now change the name of a pipeline in the jsoneditor without creating a new pipeline.
- Most fields are now uneditable in the jsoneditor since they should never be edited.

Answering question 4. of #16  : you can't create pipelines without prefix `alarm_`, `control_`, or `convert_` . You will get an error message. This is intentional. 
