### PR TITLE
Performance improvements

### DIFF
--- a/public/javascripts/full_system.js
+++ b/public/javascripts/full_system.js
@@ -1,6 +1,3 @@
-const sensors = [];
-const units = {};
-
 // Settings:
 var SIG_FIGS = 3;
 var LOG_THRESHOLD = 3;
@@ -42,7 +39,6 @@ function GetGroupedSensors() {
     data.forEach(group => {
       var click = group_by == 'device' ? `onclick='DeviceDropdown("${group._id}")'` : "";
       var head = `<thead id=${group._id}><tr ${click}><th colspan=2> ${group._id}</th></tr></thead><tbody id="${group._id}_tbody">`;
-      group['sensors'].forEach(doc => units[doc.name] = doc.units);
       $("#jump_to_list").append(`<li><a class="dropdown-item py-2" href="#${group._id}">${group._id}</a></li>`)
       $("#sensor_table").append(head + group['sensors'].reduce((tot, rd) => tot + `<tr><td id="${rd.name}_desc" onclick="SensorDropdown('${rd.name}')">Loading!</td><td id="${rd.name}_status">Loading!</td></tr>`, "") + '</tbody>');
     }); // data.forEach
@@ -70,11 +66,10 @@ function UpdateOnce() {
          // Add any possible new sensor
          if (!$(`#${doc.name}_status`).length)
            $(`#${group._id}`).append(`<tr><td id="${doc.name}_desc" onclick="SensorDropdown('${doc.name}')">Loading!</td><td id="${doc.name}_status">Loading!</td></tr>`);
-         units[doc.name] = doc.units;
          $(`#${doc.name}_desc`).html(`${doc.desc} (${doc.name})`);
          var last_point = data[0][doc.name];
          if (last_point && (last_point.value))
-           var new_status = `${SigFigs(last_point.value)} ${units[last_point.sensor]} (${last_point.time_ago}s ago)`;
+           var new_status = `${SigFigs(last_point.value)} ${doc.units} (${last_point.time_ago}s ago)`;
          else
            var new_status = 'No recent data';
          if (doc.status == 'offline') {

--- a/public/javascripts/full_system.js
+++ b/public/javascripts/full_system.js
@@ -13,7 +13,7 @@ function PopulateNavbar() {
       '<span>Add sensor &nbsp<i class="fas fa-solid fa-plus"></i><i class="fas fa-solid fa-thermometer"></i></span>' +
       '</button></li>' +
       '<li class="nav-item"><div class="d-flex"><div class="navbar-text">&nbsp; Group by: &nbsp;</div>' +
-      '<div class="btn-group" id="sensor_grouping" role="group" onclick="UpdateOnce(regoup=true)"> ' +
+      '<div class="btn-group" id="sensor_grouping" role="group" onchange="UpdateOnce(regoup=true)"> ' +
       '<input class="btn-check" id="groupSubsystem" type="radio" name="btnradio" value="subsystem" checked=""> ' +
       '<label class="btn btn-outline-primary" for="groupSubsystem">Subsystem</label> ' +
       '<input class="btn-check" id="groupSensor" type="radio" name="btnradio" value="device"> ' +

--- a/public/javascripts/full_system.js
+++ b/public/javascripts/full_system.js
@@ -59,28 +59,13 @@ function SigFigs(val) {
 }
 
 function UpdateOnce() {
-
-  sensors.forEach(r => {
-    $.getJSON('/devices/get_last_points', data => {
-      data.forEach(val => {
-        if (val.value)
-          $(`#${r}_status`).html(`${SigFigs(val.value)} ${units[r]} (${val.time_ago}s ago)`);
-        else
-          $(`#${r}_status`).html('DELAYED');
-      })
-    });
-    $.getJSON(`/devices/sensor_detail?sensor=${r}`, data => {
-      if(data['status'] == 'offline')
-        $(`#${r}_status`).html('OFFLINE');
-      else {
-        $.getJSON(`/devices/get_last_point?sensor=${r}`, (val) => {
-          if (val.value)
-            $(`#${r}_status`).html(`${SigFigs(val.value)} ${units[r]} (${val.time_ago}s ago)`);
-          else
-            $(`#${r}_status`).html('DELAYED');
-        });
-      }
-    });
+  $.getJSON('/devices/get_last_points', data => {
+    data.forEach(val => {
+      if (val.value)
+        $(`#${val.sensor}_status`).html(`${SigFigs(val.value)} ${units[val.sensor]} (${val.time_ago}s ago)`);
+      else
+        $(`#${val.sensor}_status`).html('DELAYED');
+    })
   });
 }
 

--- a/public/javascripts/full_system.js
+++ b/public/javascripts/full_system.js
@@ -59,7 +59,16 @@ function SigFigs(val) {
 }
 
 function UpdateOnce() {
+
   sensors.forEach(r => {
+    $.getJSON('/devices/get_last_points', data => {
+      data.forEach(val => {
+        if (val.value)
+          $(`#${r}_status`).html(`${SigFigs(val.value)} ${units[r]} (${val.time_ago}s ago)`);
+        else
+          $(`#${r}_status`).html('DELAYED');
+      })
+    });
     $.getJSON(`/devices/sensor_detail?sensor=${r}`, data => {
       if(data['status'] == 'offline')
         $(`#${r}_status`).html('OFFLINE');

--- a/public/javascripts/full_system.js
+++ b/public/javascripts/full_system.js
@@ -55,6 +55,19 @@ function SigFigs(val) {
   return val;
 }
 
+function FormatTimeSince(seconds) {
+  v = parseFloat(seconds);
+  if (v < 10)
+    // For small numbers of seconds go down to tenths
+    return v.toFixed(1) + 's';
+  else if (v < 120)
+    return v.toFixed(0) + 's';
+  else if (v < 2 * 60 * 60)
+    return (v / 60).toFixed(0) + 'm';
+  else
+    return (v / 60 / 60).toFixed(0) + 'h';
+}
+
 function UpdateOnce() {
   var group_by = $('#sensor_grouping input:radio:checked').val();
   $.when(
@@ -69,7 +82,7 @@ function UpdateOnce() {
          $(`#${doc.name}_desc`).html(`${doc.desc} (${doc.name})`);
          var last_point = data[0][doc.name];
          if (last_point && (last_point.value))
-           var new_status = `${SigFigs(last_point.value)} ${doc.units} (${last_point.time_ago}s ago)`;
+           var new_status = `${SigFigs(last_point.value)} ${doc.units} (${FormatTimeSince(last_point.time_ago)} ago)`;
          else
            var new_status = 'No recent data';
          if (doc.status == 'offline') {

--- a/public/javascripts/systems.js
+++ b/public/javascripts/systems.js
@@ -154,9 +154,9 @@ function LoadSVG(fn) {
 function UpdateOnce() {
   var updatestarttime = Date.now();
   var doc = document.getElementById('svg_frame').getSVGDocument();
-  sensors.forEach(s => {
-    $.getJSON(`/devices/get_last_point?sensor=${s}`, data => {
-      var value = parseFloat(data.value);
+  $.getJSON(`/devices/get_last_points?sensors=${[...sensors].join(',')}`, data => {
+    sensors.forEach(s => {
+      var value = parseFloat(data[s]['value']);
       for (var element of doc.querySelectorAll(`[id^=valve_${s}]`)) {
         element.classList.remove(value ? 'off' : "on");
         element.classList.add(value ? 'on' : 'off');
@@ -166,7 +166,7 @@ function UpdateOnce() {
       }
       for (var property of properties) {
         if (property['sensor'] == s) {
-          transformedValue = value * property['scaling'] + property['offset'];
+          var transformedValue = value * property['scaling'] + property['offset'];
           transformedValue = Math.max(transformedValue, property['min']);
           transformedValue = Math.min(transformedValue, property['max']);
           var target = doc.getElementById(property['targetId']);
@@ -174,7 +174,7 @@ function UpdateOnce() {
         }
       }
     });
+    console.debug('Updating took ' + (Date.now() - updatestarttime) / 1000 + ' seconds')
   });
-  console.debug('Updating took ' + (Date.now() - updatestarttime) / 1000 + ' seconds')
 }
 

--- a/public/javascripts/systems.js
+++ b/public/javascripts/systems.js
@@ -156,6 +156,10 @@ function UpdateOnce() {
   var doc = document.getElementById('svg_frame').getSVGDocument();
   $.getJSON(`/devices/get_last_points?sensors=${[...sensors].join(',')}`, data => {
     sensors.forEach(s => {
+      if (!data[s]) {
+        console.log(`No data for sensor ${s}`);
+        return;
+      }
       var value = parseFloat(data[s]['value']);
       for (var element of doc.querySelectorAll(`[id^=valve_${s}]`)) {
         element.classList.remove(value ? 'off' : "on");

--- a/routes/devices.js
+++ b/routes/devices.js
@@ -278,12 +278,17 @@ router.get('/get_last_points', function(req, res) {
         })}).then(resp => {
           const lines = resp.data.split('\r\n');
           const keys = lines[0].split(',');
+          const value_index = keys.indexOf('_value');
+          const time_index = keys.indexOf('time');
+          const sensor_index = keys.indexOf('sensor');
           return res.json(lines.slice(1).map(line => {
-            return line.split(',').reduce((acc, cur, i) => {
-                const toAdd = {};
-                toAdd[keys[i]] = cur;
-                return { ...acc, ...toAdd };
-            }, {});
+            const v = line.split(',');
+            return {
+              'value': v[value_index],
+              'sensor': v[sensor_index],
+              'time': v[time_index],
+              'time_ago': ((new Date() - new Date(v[time_index])) / 1000).toFixed(1),
+            };
           }));
   }).catch(err => {console.log(err); return res.json({});});
 });

--- a/routes/devices.js
+++ b/routes/devices.js
@@ -94,7 +94,12 @@ router.get('/sensors_grouped', function(req, res) {
     {$sort: {'name': 1}},
     {$group: {
       _id: '$' + group_by,
-      sensors: {$push: {name: '$name', desc: '$description', units: '$units'}}
+      sensors: {$push: {
+        name: '$name',
+        desc: '$description',
+        units: '$units',
+        status: '$status'
+      }}
     }},
     {$sort: {_id: 1}}
   ]).then(docs => res.json(docs))
@@ -285,15 +290,15 @@ router.get('/get_last_points', function(req, res) {
             if ((line.length > 0) & (!line.includes('_value'))) {
               // Sometimes Influx sends extra header lines!
               const v = line.split(',');
-              result.push({
+              result[v[sensor_index]] = {
                 'value': v[value_index],
                 'sensor': v[sensor_index],
                 'time': v[time_index],
                 'time_ago': ((new Date() - new Date(v[time_index])) / 1000).toFixed(1),
-              });
+              };
             }
             return result;
-          }, []));
+          }, {}));
   }).catch(err => {console.log(err); return res.json({});});
 });
 

--- a/routes/devices.js
+++ b/routes/devices.js
@@ -276,7 +276,7 @@ router.get('/get_last_points', function(req, res) {
             'Content-type': 'application/vnd.flux'
           },
         })}).then(resp => {
-          const lines = csv.split('\n');
+          const lines = resp.data.split('\r\n');
           const keys = lines[0].split(',');
           return lines.slice(1).map(line => {
             return line.split(',').reduce((acc, cur, i) => {

--- a/routes/devices.js
+++ b/routes/devices.js
@@ -278,13 +278,13 @@ router.get('/get_last_points', function(req, res) {
         })}).then(resp => {
           const lines = resp.data.split('\r\n');
           const keys = lines[0].split(',');
-          return lines.slice(1).map(line => {
+          return res.json(lines.slice(1).map(line => {
             return line.split(',').reduce((acc, cur, i) => {
                 const toAdd = {};
                 toAdd[keys[i]] = cur;
                 return { ...acc, ...toAdd };
             }, {});
-          });
+          }));
   }).catch(err => {console.log(err); return res.json({});});
 });
 

--- a/routes/devices.js
+++ b/routes/devices.js
@@ -279,17 +279,21 @@ router.get('/get_last_points', function(req, res) {
           const lines = resp.data.split('\r\n');
           const keys = lines[0].split(',');
           const value_index = keys.indexOf('_value');
-          const time_index = keys.indexOf('time');
+          const time_index = keys.indexOf('_time');
           const sensor_index = keys.indexOf('sensor');
-          return res.json(lines.slice(1).map(line => {
-            const v = line.split(',');
-            return {
-              'value': v[value_index],
-              'sensor': v[sensor_index],
-              'time': v[time_index],
-              'time_ago': ((new Date() - new Date(v[time_index])) / 1000).toFixed(1),
-            };
-          }));
+          return res.json(lines.slice(1).reduce((result, line) => {
+            if ((line.length > 0) & (!line.includes('_value'))) {
+              // Sometimes Influx sends extra header lines!
+              const v = line.split(',');
+              result.push({
+                'value': v[value_index],
+                'sensor': v[sensor_index],
+                'time': v[time_index],
+                'time_ago': ((new Date() - new Date(v[time_index])) / 1000).toFixed(1),
+              });
+            }
+            return result;
+          }, []));
   }).catch(err => {console.log(err); return res.json({});});
 });
 

--- a/views/full_system.pug
+++ b/views/full_system.pug
@@ -11,7 +11,6 @@ block content
     $(document).ready(function () {
       PopulateNavbar();
       GetGroupedSensors();
-      PopulateSensors();
       setInterval(UpdateOnce, 5000);
       var query_search = new URLSearchParams(window.location.search);
       if (query_search.has('notify_msg')) {

--- a/views/full_system.pug
+++ b/views/full_system.pug
@@ -10,7 +10,7 @@ block content
   script.
     $(document).ready(function () {
       PopulateNavbar();
-      GetGroupedSensors();
+      UpdateOnce(regroup=true);
       setInterval(UpdateOnce, 5000);
       var query_search = new URLSearchParams(window.location.search);
       if (query_search.has('notify_msg')) {


### PR DESCRIPTION
Doberview was using a ridiculous amount of CPU doing several hundred AJAX requests each time it got new data.

Now whenever updating the devices page, get all sensor data in a single request (via the new get_last_points endpoint). This request takes no appreciable time longer than a single get_last_point call (around 15-20 ms in both cases for my tests on the uni network).
A single request is also performed to find offline sensors (in practice, the sensors_grouped endpoint is used both when initially populating the sensors and when updating the page.

At the same time interactivity is improved:
- Modified sensor descriptions show up in the page without the need for a refresh.
- Newly added sensors also appear without needing to reload the page.

Profiler showing the reduction in resource usage before: https://share.firefox.dev/3GihtOi
and after: https://share.firefox.dev/3ib7iD8

Similarly for the systems view, using the systems= GET parameter, get all the data for sensors on a particular SVG. Again gives a significant performance boost (although the old version was not so bad here) from: https://share.firefox.dev/3QdAhms
to: https://share.firefox.dev/3X523Up

Since the update function simply gets all the sensor information anyway, there is no need for a separate GetGroupedSensors or PopulateSensors function, UpdateOnce does it all (regrouping when the optional regroup parameter is true). Incidentally, mongo access seems to be very fast compared to the type of flux query we are using here, so there is no real need to try to save time there at the cost of complication.

In addition, the time since reading is now shown in minutes if it is greater than 2 minutes, and in hours if greater than 2 hours.