### PR TITLE
Pipeline control buttons in sensor details

### DIFF
--- a/public/javascripts/default_scripts.js
+++ b/public/javascripts/default_scripts.js
@@ -94,18 +94,19 @@ function SensorDropdown(sensor) {
               `data-bs-placement="right" title="process time: &nbsp; ${doc.rate.toPrecision(3)} ms  \n`+
               `last cycle: &nbsp; ${((now-doc.heartbeat)/1000 || 0).toPrecision(1)} s \n`+
               `last error: &nbsp; ${doc.cycles - doc.error} cycles ago"><span class="visually-hidden">X</span></span></td>`;
-          let goto_btn = `<button class="btn btn-primary action_button" `+
-              `onclick="location.href='pipeline?pipeline_id=${pl_name}'"> Go to</button>`;
+          let stop_btn = `<button class="btn btn-danger action_button" `+
+              `onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_stop ${pl_name}')">`+
+              `<i class="fas fa-solid fa-stop"></i>Stop</button>`;
+          let start_btn = `<button class="btn btn-success action_button" onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_start ${pl_name}')"><i class="fas fa-solid fa-play"></i>Start</button>`;
+          let restart_btn = `<button class="btn btn-primary action_button" onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_restart ${pl_name}')"><i class="fas fa-solid fa-rotate"></i>Restart</button>`;
+          let silence_btn = `<button class="btn btn-secondary action_button" onclick="SilenceDropdown('${pl_name}')"><i class="fas fa-solid fa-bell-slash"></i>Silence</button>`;
+          let activate_btn = `<button class="btn btn-success action_button" onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_active ${pl_name}')"><i class="fas fa-solid fa-play"></i>Activate</button>`;
           if (doc.status === 'active') {
-            let stop_btn = `<button class="btn btn-danger action_button" `+
-                `onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_stop ${pl_name}')">`+
-                `<i class="fas fa-solid fa-stop"></i>Stop</button>`;
-            $("#pipelines_active").append(`<tr><td>${error_status}</td><td>${pl_name}</td><td>`+stop_btn+`</td><td>`+goto_btn+`</td></tr>`);
+            $("#pipelines_active").append(`<tr><td>${error_status}</td><td>${pl_name}</td><td>`+silence_btn+`</td><td>`+stop_btn+`</td><td>`+restart_btn+`</td></tr>`);
           } else if (doc.status === 'silent') {
-            $("#pipelines_silenced").append(`<tr><td>${error_status}</td><td>${pl_name}</td><td>`+goto_btn+`</td></tr>`);
+            $("#pipelines_silenced").append(`<tr><td>${error_status}</td><td>${pl_name}</td><td>`+activate_btn+`</td><td>`+stop_btn+`</td><td>`+restart_btn+`</td></tr>`);
           } else {
-            let start_btn = `<button class="btn btn-success action_button" onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_start ${pl_name}')"><i class="fas fa-solid fa-play"></i>Start</button>`;
-            $("#pipelines_inactive").append(`<tr><td>${error_status}</td><td>${pl_name}</td><td>`+start_btn+`</td><td>`+goto_btn+`</td></tr>`);
+            $("#pipelines_inactive").append(`<tr><td>${error_status}</td><td>${pl_name}</td><td>`+start_btn+`</td></tr>`);
           }
           $('[data-bs-toggle="tooltip"]').tooltip();
         }); // get json

--- a/public/javascripts/default_scripts.js
+++ b/public/javascripts/default_scripts.js
@@ -94,17 +94,17 @@ function SensorDropdown(sensor) {
               `data-bs-placement="right" title="process time: &nbsp; ${doc.rate.toPrecision(3)} ms  \n`+
               `last cycle: &nbsp; ${((now-doc.heartbeat)/1000 || 0).toPrecision(1)} s \n`+
               `last error: &nbsp; ${doc.cycles - doc.error} cycles ago"><span class="visually-hidden">X</span></span></td>`;
-          let stop_btn = `<button class="btn btn-danger action_button" `+
+          let stop_btn = `<div class="col text-center"><button class="btn btn-danger action_button" `+
               `onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_stop ${pl_name}')">`+
-              `<i class="fas fa-solid fa-stop"></i>Stop</button>`;
-          let start_btn = `<button class="btn btn-success action_button" onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_start ${pl_name}')"><i class="fas fa-solid fa-play"></i>Start</button>`;
-          let restart_btn = `<button class="btn btn-primary action_button" onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_restart ${pl_name}')"><i class="fas fa-solid fa-rotate"></i>Restart</button>`;
-          let silence_btn = `<button class="btn btn-secondary action_button" onclick="SilenceDropdown('${pl_name}')"><i class="fas fa-solid fa-bell-slash"></i>Silence</button>`;
-          let activate_btn = `<button class="btn btn-success action_button" onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_active ${pl_name}')"><i class="fas fa-solid fa-play"></i>Activate</button>`;
-          if (doc.status === 'active') {
+              `<i class="fas fa-solid fa-stop"></i></button></div>`;
+          let start_btn = `<button class="btn btn-success action_button" onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_start ${pl_name}')"><i class="fas fa-solid fa-play"></i></button>`;
+          let restart_btn = `<button class="btn btn-primary action_button" onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_restart ${pl_name}')"><i class="fas fa-solid fa-rotate"></i></button>`;
+          let silence_btn = `<button class="btn btn-secondary action_button" onclick="SilenceDropdown('${pl_name}')"><i class="fas fa-solid fa-bell-slash"></i></button>`;
+          let activate_btn = `<button class="btn btn-success action_button" onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_active ${pl_name}')"><i class="fas fa-solid fa-play"></i></button>`;
+          if ((doc.status === 'active') && ((doc.silent_until == -1) || (doc.silent_until > Date.now()/1000))) {
+            $("#pipelines_silenced").append(`<tr><td>${error_status}</td><td>${pl_name}</td><td>`+activate_btn+`</td><td>`+silence_btn+`</td><td>`+stop_btn+`</td><td>`+restart_btn+`</td></tr>`);
+          } else if (doc.status === 'active') {
             $("#pipelines_active").append(`<tr><td>${error_status}</td><td>${pl_name}</td><td>`+silence_btn+`</td><td>`+stop_btn+`</td><td>`+restart_btn+`</td></tr>`);
-          } else if (doc.status === 'silent') {
-            $("#pipelines_silenced").append(`<tr><td>${error_status}</td><td>${pl_name}</td><td>`+activate_btn+`</td><td>`+stop_btn+`</td><td>`+restart_btn+`</td></tr>`);
           } else {
             $("#pipelines_inactive").append(`<tr><td>${error_status}</td><td>${pl_name}</td><td>`+start_btn+`</td></tr>`);
           }

--- a/public/javascripts/default_scripts.js
+++ b/public/javascripts/default_scripts.js
@@ -94,9 +94,7 @@ function SensorDropdown(sensor) {
               `data-bs-placement="right" title="process time: &nbsp; ${doc.rate.toPrecision(3)} ms  \n`+
               `last cycle: &nbsp; ${((now-doc.heartbeat)/1000 || 0).toPrecision(1)} s \n`+
               `last error: &nbsp; ${doc.cycles - doc.error} cycles ago"><span class="visually-hidden">X</span></span></td>`;
-          let stop_btn = `<div class="col text-center"><button class="btn btn-danger action_button" `+
-              `onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_stop ${pl_name}')">`+
-              `<i class="fas fa-solid fa-stop"></i></button></div>`;
+          let stop_btn = `<button class="btn btn-danger action_button" onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_stop ${pl_name}')"> <i class="fas fa-solid fa-stop"></i></button>`;
           let start_btn = `<button class="btn btn-success action_button" onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_start ${pl_name}')"><i class="fas fa-solid fa-play"></i></button>`;
           let restart_btn = `<button class="btn btn-primary action_button" onclick="SendToHypervisor('pl_${flavor}', 'pipelinectl_restart ${pl_name}')"><i class="fas fa-solid fa-rotate"></i></button>`;
           let silence_btn = `<button class="btn btn-secondary action_button" onclick="SilenceDropdown('${pl_name}')"><i class="fas fa-solid fa-bell-slash"></i></button>`;

--- a/public/javascripts/default_scripts.js
+++ b/public/javascripts/default_scripts.js
@@ -615,3 +615,25 @@ function ChangeSetpoint() {
   }
 }
 
+function SilenceDropdown(name) {
+  $('#silence_me').html(name);
+  $('#silence_dropdown').modal('show');
+}
+
+function SilencePipeline(duration) {
+  var name = $("#silence_me").html();
+  $.ajax({
+    type: 'POST',
+    url: "/pipeline/pipeline_silence",
+    data: {name: name, duration: duration},
+    success: (data) => {
+      if (typeof data != 'undefined' && typeof data.err != 'undefined')
+        alert(data.err);
+      else
+        $("#silence_dropdown").modal('hide');
+        PopulatePipelines();
+        Notify(data.notify_msg, data.notify_status);
+    },
+    error: (jqXHR, textStatus, errorCode) => alert(`Error: ${textStatus}, ${errorCode}`),
+  });
+}

--- a/public/javascripts/pipeline.js
+++ b/public/javascripts/pipeline.js
@@ -99,11 +99,6 @@ function Visualize(doc) {
   });
 }
 
-function SilenceDropdown(name) {
-  $('#silence_me').html(name);
-  $('#silence_dropdown').modal('show');
-}
-
 function AlarmTemplate() {
   return {
     name: 'alarm_NAME',
@@ -335,24 +330,6 @@ function DeletePipeline() {
 
 function StartPipeline(name) {
   PipelineControl('start', name);
-}
-
-function SilencePipeline(duration) {
-  var name = $("#silence_me").html();
-  $.ajax({
-    type: 'POST',
-    url: "/pipeline/pipeline_silence",
-    data: {name: name, duration: duration},
-    success: (data) => {
-      if (typeof data != 'undefined' && typeof data.err != 'undefined')
-        alert(data.err);
-      else
-        $("#silence_dropdown").modal('hide');
-        PopulatePipelines();
-        Notify(data.notify_msg, data.notify_status);
-    },
-    error: (jqXHR, textStatus, errorCode) => alert(`Error: ${textStatus}, ${errorCode}`),
-  });
 }
 
 function PipelineControl(action, pipeline) {

--- a/public/stylesheets/default_style.css
+++ b/public/stylesheets/default_style.css
@@ -126,14 +126,7 @@ ul.CTAs li a {
 }
 
 .modal-backdrop {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
   z-index: 1040;
-  background-color: #000;
-  opacity: 0.2;
 }
 
 .modal-backdrop + .modal-backdrop {
@@ -147,5 +140,5 @@ ul.CTAs li a {
 
 #sensorbox.modal.fade.show {
   display: block;
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(0, 0, 0, 0.05);
 }

--- a/public/stylesheets/default_style.css
+++ b/public/stylesheets/default_style.css
@@ -120,9 +120,9 @@ ul.CTAs li a {
   word-break: break-word;
 }
 
-
 .modal-container {
   position: relative;
+  z-index: 1050;
 }
 
 .modal-backdrop {
@@ -131,8 +131,21 @@ ul.CTAs li a {
   left: 0;
   right: 0;
   bottom: 0;
+  z-index: 1040;
+  background-color: #000;
+  opacity: 0.2;
 }
 
 .modal-backdrop + .modal-backdrop {
   z-index: 1040;
+}
+
+#silence_dropdown.modal.fade.show {
+  display: block;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+#sensorbox.modal.fade.show {
+  display: block;
+  background: rgba(0, 0, 0, 0.2);
 }

--- a/public/stylesheets/default_style.css
+++ b/public/stylesheets/default_style.css
@@ -119,3 +119,20 @@ ul.CTAs li a {
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+
+.modal-container {
+  position: relative;
+}
+
+.modal-backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.modal-backdrop + .modal-backdrop {
+  z-index: 1040;
+}

--- a/public/stylesheets/default_style.css
+++ b/public/stylesheets/default_style.css
@@ -101,7 +101,9 @@ ul.CTAs li a {
 }
 
 .action_button i {
+  margin-left: 5px;
   margin-right: 5px;
+  text-align: center;
 }
 
 #pipelines_of_sensor_table tbody tr td {

--- a/public/stylesheets/pipeline.css
+++ b/public/stylesheets/pipeline.css
@@ -5,7 +5,7 @@
 }
 
 .action_button {
-  margin-right : 10px;
+  margin-right: 10px;
 }
 
 #clear_search_btn {

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -309,7 +309,7 @@ html
           .modal-footer
             button.btn.btn-secondary(type='button' data-bs-dismiss='modal') Cancel
 
-    #newsensor.modal.fade(tabindex="-1")
+    #newsensor.modal.fade
       .modal-dialog.modal-lg
         .modal-content
           .modal-header

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -289,6 +289,26 @@ html
             button.btn.btn-secondary(type='button' data-bs-dismiss='modal') Close
             button.btn.btn-primary(type='button') Save changes
 
+    #silence_dropdown.modal.fade
+      .modal-dialog.modal-sm
+        .modal-content
+          .modal-header
+            h5.modal-title
+              span
+                |Silence
+                #silence_me
+            button.btn-close(type='button' data-bs-dismiss='modal' aria-label='Close')
+          .modal-body
+            .btn-group-vertical.d-flex.p-2
+              button.btn.btn-primary.my-1(onclick="SilencePipeline(30)") 30 minutes
+              button.btn.btn-primary.my-1(onclick="SilencePipeline(120)") 2 hours
+              button.btn.btn-primary.my-1(onclick="SilencePipeline('evening')") 18:00 today
+              button.btn.btn-primary.my-1(onclick="SilencePipeline('morning')") 09:30 tomorrow
+              button.btn.btn-primary.my-1(onclick="SilencePipeline('monday')") Monday morning
+              button.btn.btn-danger.my-1(onclick="SilencePipeline('forever')") The end of time
+          .modal-footer
+            button.btn.btn-secondary(type='button' data-bs-dismiss='modal') Cancel
+
     #newsensor.modal.fade(tabindex="-1")
       .modal-dialog.modal-lg
         .modal-content

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -84,151 +84,173 @@ html
         .toast-body
     #notify_error.toast.bg-danger.translate-middle-x(role='alert' aria-live='assertive' aria-atomic='true')
       .toast-body
-    #sensorbox.modal.fade(tabindex="-1" aria-labelledby="sensorboxLabel" aria-hidden="true")
-      .modal-dialog.modal-xl
-        .modal-content
-          .modal-header
-            h5.modal-title#detail_sensor_name
-            button.btn-close(type="button" data-bs-dismiss="modal" aria-label="Close")
-          .modal-body.row
-            .col-lg-6
-              h5 General info
-              br
-              table
-                tbody
-                  tr
-                    th.py-2 Status
-                    td
-                      input#sensor_status(type="checkbox" data-size='sm' data-width='65px' data-toggle='toggle' data-onstyle='success' data-offstyle='warning' data-on='Online' data-off='Offline')
-                  tr
-                    th.py-2 Device
-                    td
-                      button.btn.btn-primary.btn-sm#sensor_device_name
-                  tr
-                    th.py-2 Description
-                    td
-                      input.form-control-sm(type="text" id="sensor_desc" name="sensor_desc" size='4')
-                  tr
-                    th.py-2 Readout interval &nbsp;
-                    td
-                      input.form-control-sm(type="number" id="readout_interval" name="readout_interval" max="300" size='4')
-                      span &nbsp; s
-                  tr
-                    th.py-2 Units
-                    td
-                      input.form-control-sm(type="text" id="sensor_units" name="sensor_units" placeholder="")
-                  tr
-                    th.py-2 Readout command &nbsp;
-                    td#readout_command(style='font-family:"Courier New",monospace')
-                  tr
-                    th.py-2 Transform:
-                    td
-                      input.form-control-sm(type="text" id="value_xform" name="value_xform" placeholder="0,1")
-                  tr
-                    th.py-2
-                      button.btn.btn-primary(onclick="UpdateSensor()") Update
-              hr
-              h5 Alarms
-              br
-              table#alarm_table.table
-                tbody#int_alarm_body
-                tbody#float_alarm_body
-                  tr
-                    th Low
-                    th High
-                  tr
-                    td
-                      input.form-control-sm(type="number" id="alarm_low" name="alarm_low" size='6')
-                    td
-                      input.form-control-sm(type="number" id="alarm_high" name="alarm_high" size='6')
-                  tr
-                    th Setpoint
-                    th Half-range
-                  tr
-                    td
-                      input.form-control-sm(type="number" id="alarm_mid" name="alarm_mid" size='6')
-                    td
-                      input.form-control-sm(type="number" id="alarm_range" name="alarm_range" size='6')
-                tfoot
-                  tr
-                    th Recurrence
-                    th Base level
-                  tr
-                    td
-                      input.form-control-sm(type="number" id="alarm_recurrence" name="alarm_recurrence" min="1" step="1" size='8')
-                    td
-                      input.form-control-sm(type="number" id="alarm_baselevel" name="alarm_baselevel" min="0" step="1" max="3" size='8')
-                  tr
-                    th.py-2(colspan=2)
-                      button.btn.btn-primary#change_alarms(onclick="UpdateAlarms()") Update alarm
-            .col-lg-6
-              div#sensor_control
-                h5 Control
-                span#control_target(hidden)
+      
+    div.modal-container  
+      #sensorbox.modal.fade(tabindex="-1" aria-labelledby="sensorboxLabel" aria-hidden="true")
+        .modal-dialog.modal-xl
+          .modal-content
+            .modal-header
+              h5.modal-title#detail_sensor_name
+              button.btn-close(type="button" data-bs-dismiss="modal" aria-label="Close")
+            .modal-body.row
+              .col-lg-6
+                h5 General info
                 br
                 table
                   tbody
-                    tr#sensor_valve
+                    tr
+                      th.py-2 Status
                       td
-                        button.btn.btn-primary#sensor_valve_btn(onclick="ToggleValve()") Toggle
+                        input#sensor_status(type="checkbox" data-size='sm' data-width='65px' data-toggle='toggle' data-onstyle='success' data-offstyle='warning' data-on='Online' data-off='Offline')
+                    tr
+                      th.py-2 Device
                       td
-                        span#current_valve_state(hidden)
-                    tr#sensor_setpoint
+                        button.btn.btn-primary.btn-sm#sensor_device_name
+                    tr
+                      th.py-2 Description
                       td
-                        input.form-control(type="number" id="sensor_setpoint_control" name="sensor_setpoint_control" size='8')
+                        input.form-control-sm(type="text" id="sensor_desc" name="sensor_desc" size='4')
+                    tr
+                      th.py-2 Readout interval &nbsp;
                       td
-                        button.btn.btn-primary#sensor_setpoint_btn(onclick="ChangeSetpoint()") Set
+                        input.form-control-sm(type="number" id="readout_interval" name="readout_interval" max="300" size='4')
+                        span &nbsp; s
+                    tr
+                      th.py-2 Units
+                      td
+                        input.form-control-sm(type="text" id="sensor_units" name="sensor_units" placeholder="")
+                    tr
+                      th.py-2 Readout command &nbsp;
+                      td#readout_command(style='font-family:"Courier New",monospace')
+                    tr
+                      th.py-2 Transform:
+                      td
+                        input.form-control-sm(type="text" id="value_xform" name="value_xform" placeholder="0,1")
+                    tr
+                      th.py-2
+                        button.btn.btn-primary(onclick="UpdateSensor()") Update
                 hr
-              h5 Recent history
-              br
-              table
-                tbody
-                  tr
-                    th.py2 Last value
-                    td#last_value XXX
-              .d-flex.flex-row
-                .mr-auto.p-2
-                  input#plot_alarms(type="checkbox" data-toggle='toggle' data-width='110px' data-on='<i class="fa-solid fa-eye"></i>&nbsp limits' data-off='<i class="fa-regular fa-eye-slash"></i>&nbsp limits' data-onstyle='danger' data-offstyle='secondary' onchange="DrawSensorHistory()")
-                  input#plot_zoom(type="checkbox" data-toggle='toggle' data-width='130px' data-on='<i class="fa-regular fa-eye-slash"></i>&nbsp outliers' data-off='<i class="fa-solid fa-eye"></i>&nbsp outliers' data-onstyle='primary' data-offstyle='secondary' onchange="DrawSensorHistory()")
-                  input#plot_log(type="checkbox" data-toggle='toggle' data-width='80px' data-on='log' data-off='linear' data-onstyle='primary' data-offstyle='secondary' onchange="DrawSensorHistory()")
-                .p-2(style="margin-left:auto")
-                  select.form-select#selectinterval(onchange="DrawSensorHistory()")
-                    option(value="0") 10m
-                    option(value="1") 1h
-                    option(value="2") 3h
-                    option(value="3") 6h
-                    option(value="4" selected) 12h
-                    option(value="5") 24h
-                    option(value="6") 48h
-                    option(value="7") 72h
-                    option(value="8") 1w
-                    option(value="9") 2w
-                    option(value="10") 4w
-                .p-2
-                  button.btn.btn-outline-secondary.mx-1#refresh_btn(onclick='DrawSensorHistory()')
-                    i.fa.fa-sync-alt
+                h5 Alarms
+                br
+                table#alarm_table.table
+                  tbody#int_alarm_body
+                  tbody#float_alarm_body
+                    tr
+                      th Low
+                      th High
+                    tr
+                      td
+                        input.form-control-sm(type="number" id="alarm_low" name="alarm_low" size='6')
+                      td
+                        input.form-control-sm(type="number" id="alarm_high" name="alarm_high" size='6')
+                    tr
+                      th Setpoint
+                      th Half-range
+                    tr
+                      td
+                        input.form-control-sm(type="number" id="alarm_mid" name="alarm_mid" size='6')
+                      td
+                        input.form-control-sm(type="number" id="alarm_range" name="alarm_range" size='6')
+                  tfoot
+                    tr
+                      th Recurrence
+                      th Base level
+                    tr
+                      td
+                        input.form-control-sm(type="number" id="alarm_recurrence" name="alarm_recurrence" min="1" step="1" size='8')
+                      td
+                        input.form-control-sm(type="number" id="alarm_baselevel" name="alarm_baselevel" min="0" step="1" max="3" size='8')
+                    tr
+                      th.py-2(colspan=2)
+                        button.btn.btn-primary#change_alarms(onclick="UpdateAlarms()") Update alarm
+              .col-lg-6
+                div#sensor_control
+                  h5 Control
+                  span#control_target(hidden)
+                  br
+                  table
+                    tbody
+                      tr#sensor_valve
+                        td
+                          button.btn.btn-primary#sensor_valve_btn(onclick="ToggleValve()") Toggle
+                        td
+                          span#current_valve_state(hidden)
+                      tr#sensor_setpoint
+                        td
+                          input.form-control(type="number" id="sensor_setpoint_control" name="sensor_setpoint_control" size='8')
+                        td
+                          button.btn.btn-primary#sensor_setpoint_btn(onclick="ChangeSetpoint()") Set
+                  hr
+                h5 Recent history
+                br
+                table
+                  tbody
+                    tr
+                      th.py2 Last value
+                      td#last_value XXX
+                .d-flex.flex-row
+                  .mr-auto.p-2
+                    input#plot_alarms(type="checkbox" data-toggle='toggle' data-width='110px' data-on='<i class="fa-solid fa-eye"></i>&nbsp limits' data-off='<i class="fa-regular fa-eye-slash"></i>&nbsp limits' data-onstyle='danger' data-offstyle='secondary' onchange="DrawSensorHistory()")
+                    input#plot_zoom(type="checkbox" data-toggle='toggle' data-width='130px' data-on='<i class="fa-regular fa-eye-slash"></i>&nbsp outliers' data-off='<i class="fa-solid fa-eye"></i>&nbsp outliers' data-onstyle='primary' data-offstyle='secondary' onchange="DrawSensorHistory()")
+                    input#plot_log(type="checkbox" data-toggle='toggle' data-width='80px' data-on='log' data-off='linear' data-onstyle='primary' data-offstyle='secondary' onchange="DrawSensorHistory()")
+                  .p-2(style="margin-left:auto")
+                    select.form-select#selectinterval(onchange="DrawSensorHistory()")
+                      option(value="0") 10m
+                      option(value="1") 1h
+                      option(value="2") 3h
+                      option(value="3") 6h
+                      option(value="4" selected) 12h
+                      option(value="5") 24h
+                      option(value="6") 48h
+                      option(value="7") 72h
+                      option(value="8") 1w
+                      option(value="9") 2w
+                      option(value="10") 4w
+                  .p-2
+                    button.btn.btn-outline-secondary.mx-1#refresh_btn(onclick='DrawSensorHistory()')
+                      i.fa.fa-sync-alt
 
-              .container.sensor_chart#sensor_chart
+                .container.sensor_chart#sensor_chart
 
-              h5 Pipelines involving this sensor
-              br
-              button.btn.btn-primary#make_alarm_button(onclick=`MakeAlarm()`) Make new alarm
-              table.table#pipelines_of_sensor_table(style="width:100%;")
-                thead
-                  tr
-                    th(colspan='2') Active
-                tbody#pipelines_active
-                thead
-                  tr
-                    th(colspan='2') Silenced
-                tbody#pipelines_silenced
-                thead
-                  tr
-                    th(colspan='2') Inactive
-                tbody#pipelines_inactive
-              hr
-          .modal-footer
-            button.btn.btn-secondary(type="button" data-bs-dismiss="modal") Close
+                h5 Pipelines involving this sensor
+                br
+                button.btn.btn-primary#make_alarm_button(onclick=`MakeAlarm()`) Make new alarm
+                table.table#pipelines_of_sensor_table(style="width:100%;")
+                  thead
+                    tr
+                      th(colspan='2') Active
+                  tbody#pipelines_active
+                  thead
+                    tr
+                      th(colspan='2') Silenced
+                  tbody#pipelines_silenced
+                  thead
+                    tr
+                      th(colspan='2') Inactive
+                  tbody#pipelines_inactive
+                hr
+            .modal-footer
+              button.btn.btn-secondary(type="button" data-bs-dismiss="modal") Close
+
+      #silence_dropdown.modal.fade
+        .modal-dialog.modal-sm
+          .modal-content
+            .modal-header
+              h5.modal-title
+                span
+                  |Silence
+                  #silence_me
+              button.btn-close(type='button' data-bs-dismiss='modal' aria-label='Close')
+            .modal-body
+              .btn-group-vertical.d-flex.p-2
+                button.btn.btn-primary.my-1(onclick="SilencePipeline(30)") 30 minutes
+                button.btn.btn-primary.my-1(onclick="SilencePipeline(120)") 2 hours
+                button.btn.btn-primary.my-1(onclick="SilencePipeline('evening')") 18:00 today
+                button.btn.btn-primary.my-1(onclick="SilencePipeline('morning')") 09:30 tomorrow
+                button.btn.btn-primary.my-1(onclick="SilencePipeline('monday')") Monday morning
+                button.btn.btn-danger.my-1(onclick="SilencePipeline('forever')") The end of time
+            .modal-footer
+              button.btn.btn-secondary(type='button' data-bs-dismiss='modal') Cancel
 
     #devicebox.modal.fade
       .modal-dialog.modal-lg
@@ -288,26 +310,6 @@ html
           .modal-footer
             button.btn.btn-secondary(type='button' data-bs-dismiss='modal') Close
             button.btn.btn-primary(type='button') Save changes
-
-    #silence_dropdown.modal.fade
-      .modal-dialog.modal-sm
-        .modal-content
-          .modal-header
-            h5.modal-title
-              span
-                |Silence
-                #silence_me
-            button.btn-close(type='button' data-bs-dismiss='modal' aria-label='Close')
-          .modal-body
-            .btn-group-vertical.d-flex.p-2
-              button.btn.btn-primary.my-1(onclick="SilencePipeline(30)") 30 minutes
-              button.btn.btn-primary.my-1(onclick="SilencePipeline(120)") 2 hours
-              button.btn.btn-primary.my-1(onclick="SilencePipeline('evening')") 18:00 today
-              button.btn.btn-primary.my-1(onclick="SilencePipeline('morning')") 09:30 tomorrow
-              button.btn.btn-primary.my-1(onclick="SilencePipeline('monday')") Monday morning
-              button.btn.btn-danger.my-1(onclick="SilencePipeline('forever')") The end of time
-          .modal-footer
-            button.btn.btn-secondary(type='button' data-bs-dismiss='modal') Cancel
 
     #newsensor.modal.fade
       .modal-dialog.modal-lg

--- a/views/pipeline.pug
+++ b/views/pipeline.pug
@@ -8,6 +8,7 @@ block extrahead
   script(src="/modules/highcharts/modules/sankey.js", type="text/javascript")
   script(src="/modules/highcharts/modules/organization.js", type="text/javascript")
   script(src="/javascripts/pipeline.js" type="text/javascript")
+  script(src="/javascripts/default_scripts.js" type="text/javascript") 
 
     
 block content


### PR DESCRIPTION
All pipelines can now be started, activated, silenced, stopped and restarted directly from a sensor's detail menu. Has been updated with the recent silence rework.
Buttons have the same color and symbols as on the pipelines page but without text (no 'Start', 'Silence'...).
Is in use on the XeBRA doberview if you want to try it out !

Solves #51, for real this time.