### PR TITLE
Functionality for sensors with integer status value

### DIFF
--- a/public/javascripts/default_scripts.js
+++ b/public/javascripts/default_scripts.js
@@ -558,7 +558,7 @@ function SendToHypervisor(target, command, msg_if_success=null, delay=0) {
     type: 'POST',
     url: '/hypervisor/command',
     data: {target: target, command: command, delay: delay},
-    success: (data) => {if (typeof data.err != 'undefined') alert(data.err); else Notify(msg, data.notify_status);},
+    success: (data) => {if (typeof data.err != 'undefined') alert(data.err); else Notify(data.notify_msg, data.notify_status);},
     error: (jqXHR, textStatus, errorCode) => alert(`Error: ${textStatus}, ${errorCode}`)
   });
 }

--- a/public/javascripts/default_scripts.js
+++ b/public/javascripts/default_scripts.js
@@ -116,18 +116,31 @@ function SensorDropdown(sensor) {
       control_map[sensor_detail.name] = [sensor_detail.device, sensor_detail.control_quantity];
       $("#sensor_control").css('display', 'inline');
       if (sensor_detail.topic === 'status') {
-        // this is a valve
-        $("#sensor_valve").prop('hidden', false);
-        $("#sensor_setpoint").prop('hidden', true);
-        $.getJSON(`/devices/get_last_point?sensor=${sensor_detail.name}`, doc => {
-          $("#sensor_valve_btn").text(doc.value == 0 ? "Open" : "Close");
-          $("#current_valve_state").html(doc.value);
+        let valuemap = sensor_detail.valuemap;
+        if (typeof sensor_detail.valuemap !== 'undefined') {
+          $("#sensor_states").prop('hidden', false);
+          $("#sensor_valve").prop('hidden', true);
+          $("#sensor_setpoint").prop('hidden', true);
+          $("#sensor_states").empty();
+          Object.entries(valuemap).forEach(([state, label]) => {
+            $("#sensor_states").append(`<td><button class="btn btn-primary" id="sensor_valve_btn" onclick="ChangeSetpoint(${state})">${label}</button></td>`);
         });
-        control_map[sensor_detail.name].push((sensor_detail.is_normally_open !== undefined));
+        } else {
+          // this is a valve
+          $("#sensor_valve").prop('hidden', false);
+          $("#sensor_setpoint").prop('hidden', true);
+          $("#sensor_states").prop('hidden', true);
+          $.getJSON(`/devices/get_last_point?sensor=${sensor_detail.name}`, doc => {
+            $("#sensor_valve_btn").text(doc.value == 0 ? "Open" : "Close");
+            $("#current_valve_state").html(doc.value);
+          });
+          control_map[sensor_detail.name].push((sensor_detail.is_normally_open !== undefined));
+        }
       } else {
         // this is a setpoint
         $("#sensor_valve").prop('hidden', true);
         $("#sensor_setpoint").prop('hidden', false);
+        $("#sensor_states").prop('hidden', true);
         $.getJSON(`/devices/get_last_point?sensor=${sensor_detail.name}`, doc => {
           $("#sensor_setpoint_control").val(doc.value);
         });
@@ -605,12 +618,12 @@ function ToggleValve() {
   }
 }
 
-function ChangeSetpoint() {
+function ChangeSetpoint(value) {
   var sensor = $("#detail_sensor_name").html();
   var device = control_map[sensor][0];
   var target = control_map[sensor][1];
-  var value = $("#sensor_setpoint_control").val();
-  if (sensor && target && device && confirm('Confirm setpoint change')) {
+  if (value == undefined) value = $("#sensor_setpoint_control").val();
+  if (sensor && target && device && confirm(`Confirm setpoint change to ${value}`)) {
     SendToHypervisor(device, `set ${target} ${value}`, `set ${target} ${value}`);
   }
 }

--- a/public/javascripts/full_system.js
+++ b/public/javascripts/full_system.js
@@ -75,11 +75,12 @@ function UpdateOnce(regroup=false) {
          if (!$(`#${doc.name}_status`).length)
            $(`#${group._id}_tbody`).append(`<tr><td id="${doc.name}_desc" onclick="SensorDropdown('${doc.name}')">Loading!</td><td id="${doc.name}_status">Loading!</td></tr>`);
          $(`#${doc.name}_desc`).html(`${doc.desc} (${doc.name})`);
+         var new_status = 'No recent data';
          var last_point = data[0][doc.name];
-         if (last_point && (last_point.value))
-           var new_status = `${SigFigs(last_point.value)} ${doc.units} (${FormatTimeSince(last_point.time_ago)} ago)`;
-         else
-           var new_status = 'No recent data';
+         if (last_point && (last_point.value)) {
+           var displayval = (doc.valuemap == undefined) ? SigFigs(last_point.value) : doc.valuemap[parseInt(last_point.value)];
+           new_status = `${displayval} ${doc.units} (${FormatTimeSince(last_point.time_ago)} ago)`;
+         }
          if (doc.status == 'offline') {
            if (new_status.slice(-1) == ')')
              new_status = new_status.slice(0, -1) + ', ';

--- a/public/javascripts/systems.js
+++ b/public/javascripts/systems.js
@@ -42,7 +42,7 @@ function SetRefreshRate(rate) {
 function SigFigs(val) {
   LOG_THRESHOLD=3;
   SIG_FIGS=3;
-  return Math.abs(Math.log10(Math.abs(val))) < LOG_THRESHOLD ? val.toPrecision(SIG_FIGS) : val.toExponential(SIG_FIGS);
+  return Math.abs(Math.log10(Math.abs(val))) < LOG_THRESHOLD ? val.toPrecision(SIG_FIGS) : val.toExponential(SIG_FIGS-1);
 }
 
 function GetAttributeOrDefault(element, attribute, deflt) {
@@ -103,8 +103,8 @@ function Setup(){
   }
 
   // Get a full list of sensors which will need updating
-  regex = /(?<=^val[uv]e_)[^\-]+/; // Extract what comes after value or valve before -
-  var vals = doc.querySelectorAll('[id^=value_], [id^=valve_]');
+  regex = /(?<=(val[uv]e|sensdet)_)[^\-]+/; // Extract what comes after value or valve before -
+  var vals = doc.querySelectorAll('[id^=value_], [id^=valve_], [id*=sensdet_]');
   sensors = new Set(Array.from(vals, n => n.getAttribute('id').match(regex)[0]));
 
   var metadata = doc.querySelector('metadata');

--- a/public/javascripts/systems.js
+++ b/public/javascripts/systems.js
@@ -53,10 +53,12 @@ function GetAttributeOrDefault(element, attribute, deflt) {
 }
 
 function TogglePipelineConfig(e){
-  var element = e.target;
-  var pipeline = element.getAttribute('pipeline');
-  var target = element.getAttribute('target');
-  var value = 1 - parseInt(element.getAttribute('state'));
+  let element = e.target;
+  let pipeline = element.getAttribute('pipeline');
+  let target = element.getAttribute('target');
+  let value = 1 - parseInt(element.getAttribute('state'));
+  let confmsg = `Setting ${pipeline}.${target} to ${value}`;
+  if (!confirm(confmsg)) return;
   $.post('/pipeline/set_single_node_config',
          data={pipeline: pipeline, target: target, value: value},
          data => {
@@ -125,7 +127,7 @@ function Setup(){
     units[s] = data.units;
     for (var element of doc.querySelectorAll(`[id*=_${s}]`)) {
       element.addEventListener('click', function() {SensorDropdown(s);});
-      element.style['cursor'] = 'pointer';
+      element.style.cursor = 'pointer';
     }
     for (var element of doc.querySelectorAll(`[id^=descbox_${s}]`)) {
       element.textContent = `${s} (${units[s]})`;
@@ -137,7 +139,7 @@ function Setup(){
   for (var element of doc.querySelectorAll(`[id^=link_]`)) {
     linktargets[element.id] = element.getAttribute('id').match(regex)[0];
     element.addEventListener('click', LoadSVG);
-    element.style['cursor'] = 'pointer';
+    element.style.cursor = 'pointer';
   }
 
   // Check for pipeline interaction elements
@@ -159,6 +161,7 @@ function Setup(){
     toggle.setAttribute('state', 0);
     toggle.style.strokeWidth = 1;
     toggle.style.fill = '#ff0000';
+    toggle.style.cursor = 'pointer';
     toggle.onclick = TogglePipelineConfig;
     element.parentElement.appendChild(toggle);
     if (!pipelineconfigs[tbpipeline]) pipelineconfigs[tbpipeline] = [];

--- a/routes/devices.js
+++ b/routes/devices.js
@@ -94,7 +94,8 @@ router.get('/sensors_grouped', function(req, res) {
         name: '$name',
         desc: '$description',
         units: '$units',
-        status: '$status'
+        status: '$status',
+        valuemap: '$valuemap'
       }}
     }},
     {$sort: {_id: 1}}

--- a/routes/hypervisor.js
+++ b/routes/hypervisor.js
@@ -11,7 +11,7 @@ router.post('/command', common.ensureAuthenticated, function(req, res) {
   var ret = common.SendCommand(req, data.target, data.command, delay);
   if (typeof ret != 'undefined' && typeof ret.err != 'undefined')
     return res.json({err: ret.err});
-  return res.json({notify_msg: 'Command sent', notify_status: 'success'});
+  return res.json({notify_msg: `Sent ${data.command} to ${data.target}`, notify_status: 'success'});
 });
 
 router.get('/status', function(req, res) {

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -173,6 +173,7 @@ html
                         button.btn.btn-primary#sensor_valve_btn(onclick="ToggleValve()") Toggle
                       td
                         span#current_valve_state(hidden)
+                    tr#sensor_states(hidden)
                     tr#sensor_setpoint
                       td
                         input.form-control(type="number" id="sensor_setpoint_control" name="sensor_setpoint_control" size='8')


### PR DESCRIPTION
Added functionality for sensors whose value is an integer representing a status.

The new sensor field in the mongo database valuemap explains the meaning behind the various status codes. These are shown appropriately in the overview page instead of a cryptic number. You can change between statuses in the sensor details box.

Also added some functionality to the SVG view to allow users to click on sensors which don't have an associated value.

We could consider removing the notion of valve (they are a special case of integer statuses) or whether we want to do similar behaviour for them, A to streamline code and B so that the user sees "Open" and "Closed" instead of 1 and 0.